### PR TITLE
Ajusta Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
-/coverage/
+
+coverage/*


### PR DESCRIPTION
# O que mudou ? 
O coverage foi deletado do projeto no git e ajustado no código

# Motivação
Para aumento de segurança e qualidade, o coverage foi deletado do repositório, agora ele está alocado somente localmente.

# Solução Proposta
Remover o git do repositório do GitHub e ajustar o caminho do mesmo localmente.

# Critérios de aceite 
- [x] Não deixar o coverage exposto no repositório.